### PR TITLE
Use ARG instead of ENV for temporary variables

### DIFF
--- a/modules/ROOT/examples/Dockerfile.example
+++ b/modules/ROOT/examples/Dockerfile.example
@@ -1,6 +1,8 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
-ENV NAME=mycontainer VERSION=0 ARCH=x86_64
+ARG NAME=mycontainer
+ARG VERSION=0
+ARG ARCH=x86_64
 LABEL   com.redhat.component="$NAME" \
         name="$FGC/$NAME" \
         version="$VERSION" \

--- a/modules/ROOT/pages/guidelines/creation.adoc
+++ b/modules/ROOT/pages/guidelines/creation.adoc
@@ -116,7 +116,7 @@ Some additional details about how each label is to be populated.
 
 '''name''': Name of the image.  If the image replaces a standard RPM, it should have the exact same name of that RPM.  Otherwise, please see naming guidelines above.
 
-'''version''': Usually 0.  Populated from the ENV variable.  See "VERSIONING" below for explanation.
+'''version''': Usually 0.  Populated from the ARG variable.  See "VERSIONING" below for explanation.
 
 '''architecture''': usually "x86_64", unless the container image supports other/all architectures.
 


### PR DESCRIPTION
We only need those temporary variables for the container build and for the LABELS. We do not want to set those specific environment variables for the container environment itself.

Using ARG instead of ENV lets us do that.

See: https://github.com/containers/toolbox/issues/188

Signed-off-by: Timothée Ravier <tim@siosm.fr>